### PR TITLE
Fix issue where meshes get compressed to nothing

### DIFF
--- a/local-config/run-config.yaml
+++ b/local-config/run-config.yaml
@@ -1,5 +1,5 @@
 required_settings:
-        input_path: ../test_meshes           # Path to lod 0 meshes or multiscale meshe
+        input_path: ../test_meshes           # Path to lod 0 meshes or multiscale meshes
         output_path: ../test_meshes_output   # Path to write out multires meshes
         num_lods: 6                          # Number of levels of detail
         box_size: 4                          # lod 0 box size

--- a/multiresolution_mesh_creator/util/mesh_util.py
+++ b/multiresolution_mesh_creator/util/mesh_util.py
@@ -133,11 +133,13 @@ def zorder_fragments(fragments):
     Returns:
         fragments: Z-curve sorted fragments
     """
-
-    fragments, _ = zip(
-        *sorted(zip(fragments, [fragment.position for fragment in fragments]),
-                key=cmp_to_key(lambda x, y: _cmp_zorder(x[1], y[1]))))
-    return list(fragments)
+    try:
+        fragments, _ = zip(
+            *sorted(zip(fragments, [fragment.position for fragment in fragments]),
+                    key=cmp_to_key(lambda x, y: _cmp_zorder(x[1], y[1]))))
+        return list(fragments)
+    except:
+        return -1
 
 
 def rewrite_index_with_empty_fragments(path, current_lod_fragments):
@@ -389,6 +391,8 @@ def write_mesh_files(mesh_directory, object_id, fragments, current_lod, lods,
     """
 
     path = mesh_directory + "/" + object_id
-    fragments = zorder_fragments(fragments)
-    fragments = write_mesh_file(path, fragments)
-    write_index_file(path, fragments, current_lod, lods, chunk_shape)
+    if len(fragments) > 0:
+        # If len(fragments) < 0, that means that the mesh has been reduced to nothing after draco compression
+        fragments = zorder_fragments(fragments)
+        fragments = write_mesh_file(path, fragments)
+        write_index_file(path, fragments, current_lod, lods, chunk_shape)

--- a/multiresolution_mesh_creator/util/mesh_util.py
+++ b/multiresolution_mesh_creator/util/mesh_util.py
@@ -133,13 +133,11 @@ def zorder_fragments(fragments):
     Returns:
         fragments: Z-curve sorted fragments
     """
-    try:
-        fragments, _ = zip(
-            *sorted(zip(fragments, [fragment.position for fragment in fragments]),
-                    key=cmp_to_key(lambda x, y: _cmp_zorder(x[1], y[1]))))
-        return list(fragments)
-    except:
-        return -1
+
+    fragments, _ = zip(
+        *sorted(zip(fragments, [fragment.position for fragment in fragments]),
+                key=cmp_to_key(lambda x, y: _cmp_zorder(x[1], y[1]))))
+    return list(fragments)
 
 
 def rewrite_index_with_empty_fragments(path, current_lod_fragments):


### PR DESCRIPTION
During draco compression, if a mesh is too small, the custom draco compression with 10 bits can compress a mesh out of existence causing errors when trying to do operations on the fragments. Now we check to see if the fragments list actually contains anything. If not, then we are done generating the multires for the given mesh.