### PR TITLE
Updates to speed up distributed tasks

### DIFF
--- a/multiresolution_mesh_creator/util/mesh_util.py
+++ b/multiresolution_mesh_creator/util/mesh_util.py
@@ -390,7 +390,7 @@ def write_mesh_files(mesh_directory, object_id, fragments, current_lod, lods,
 
     path = mesh_directory + "/" + object_id
     if len(fragments) > 0:
-        # If len(fragments) < 0, that means that the mesh has been reduced to nothing after draco compression
+        # If len(fragments) == 0, that means that the mesh has been reduced to nothing after draco compression
         fragments = zorder_fragments(fragments)
         fragments = write_mesh_file(path, fragments)
         write_index_file(path, fragments, current_lod, lods, chunk_shape)


### PR DESCRIPTION
It turns out that `with worker_client()` is slow and clogs up dask when it is called for thousands of small objects while doing the decomposition. So now we calculate a reasonable number of workers per object decomposition and only invoke `worker_client()` when the number of workers is greater than 1.